### PR TITLE
[WIP] Automatically add remote links for GitHub PR and Merge Commit to JIRA

### DIFF
--- a/src/TicketBot/Jira.php
+++ b/src/TicketBot/Jira.php
@@ -7,6 +7,7 @@ interface Jira
     public function search(JiraProject $project, array $terms);
     public function createIssue(JiraProject $project, NewJiraIssue $newIssue);
     public function addComment(JiraIssue $issue, $comment);
+    public function addRemoteLink(JiraIssue $issue, JiraRemoteLink $remoteLink, $relationship = null);
     public function resolveIssue(JiraIssue $issue);
     public function markIssueInvalid(JiraIssue $issue);
 }

--- a/src/TicketBot/Jira/JiraRest.php
+++ b/src/TicketBot/Jira/JiraRest.php
@@ -4,6 +4,7 @@ namespace TicketBot\Jira;
 
 use TicketBot\Jira;
 use TicketBot\JiraProject;
+use TicketBot\JiraRemoteLink;
 use TicketBot\NewJiraIssue;
 use TicketBot\JiraIssue;
 use Jira_Api;
@@ -54,6 +55,22 @@ class JiraRest implements Jira
     public function addComment(JiraIssue $issue, $comment)
     {
         $this->api->addComment($issue->getId(), array('body' => $comment));
+    }
+
+    public function addRemoteLink(JiraIssue $issue, JiraRemoteLink $remoteLink, $relationship = null)
+    {
+        $this->api->api(
+            Jira_Api::REQUEST_POST,
+            sprintf('/rest/api/2/issues/%s/remotelink', $issue->getId()),
+            array(
+                'relationship' => $relationship,
+                'object' => array(
+                    'url' => $remoteLink->url,
+                    'title' => $remoteLink->title,
+                    'summary' => $remoteLink->summary,
+                )
+            )
+        );
     }
 
     public function resolveIssue(JiraIssue $issue)

--- a/src/TicketBot/Jira/JiraXmlRpc.php
+++ b/src/TicketBot/Jira/JiraXmlRpc.php
@@ -4,6 +4,7 @@ namespace TicketBot\Jira;
 
 use TicketBot\Jira;
 use TicketBot\JiraProject;
+use TicketBot\JiraRemoteLink;
 use TicketBot\NewJiraIssue;
 use TicketBot\JiraIssue;
 
@@ -64,6 +65,11 @@ class JiraXmlRpc implements Jira
     public function addComment(JiraIssue $issue, $comment)
     {
         return $this->client->call("jira1.addComment", array($this->token, $issue->key, $comment));
+    }
+
+    public function addRemoteLink(JiraIssue $issue, JiraRemoteLink $remoteLink, $relationship = null)
+    {
+        throw new \BadMethodCallException('Adding remote links to issues is currently unsupported by the XML-RPC API.');
     }
 
     public function resolveIssue(JiraIssue $issue)

--- a/src/TicketBot/JiraProject.php
+++ b/src/TicketBot/JiraProject.php
@@ -95,5 +95,34 @@ We use Jira to track the state of pull requests and the versions they got
 included in.
 TEXT;
     }
+
+    public function createMergeCommitLink(PullRequestEvent $pullRequestEvent)
+    {
+        return new JiraRemoteLink(
+            $pullRequestEvent->mergeCommitUrl(),
+            'Merge Commit',
+            sprintf(
+                '%s merged commit %s into %s at %s',
+                $pullRequestEvent->mergedBy(),
+                $pullRequestEvent->mergeCommitSha(),
+                $pullRequestEvent->baseBranch(),
+                $pullRequestEvent->mergedAt()
+            )
+        );
+    }
+
+    public function createPullRequestLink(PullRequestEvent $pullRequestEvent)
+    {
+        return new JiraRemoteLink(
+            $pullRequestEvent->issueUrl(),
+            'Pull Request',
+            $pullRequestEvent->title()
+        );
+    }
+
+    public function createPullRequestLinkRelationship(PullRequestEvent $pullRequestEvent)
+    {
+        return 'relates to PR ' . $pullRequestEvent->repositoryIssueId();
+    }
 }
 

--- a/src/TicketBot/JiraRemoteLink.php
+++ b/src/TicketBot/JiraRemoteLink.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TicketBot;
+
+class JiraRemoteLink
+{
+    public $url;
+
+    public $title;
+
+    public $summary;
+
+    public function __construct($url, $title, $summary = null)
+    {
+        $this->url = $url;
+        $this->title = $title;
+        $this->summary = $summary;
+    }
+}

--- a/src/TicketBot/PullRequestEvent.php
+++ b/src/TicketBot/PullRequestEvent.php
@@ -81,6 +81,11 @@ class PullRequestEvent
         return $pullRequestId;
     }
 
+    public function repositoryIssueId()
+    {
+        return $this->repository() . '#' . $this->getId();
+    }
+
     public function issuePrefix()
     {
         return "[GH-".$this->getId()."]";
@@ -107,8 +112,41 @@ class PullRequestEvent
         return $issueSearchTerms;
     }
 
+    public function baseBranch()
+    {
+        return $this->event['base']['ref'];
+    }
+
     public function isMerged()
     {
         return $this->event['pull_request']['merged'];
+    }
+
+    public function mergeCommitSha()
+    {
+        return $this->event['pull_request']['merge_commit_sha'];
+    }
+
+    public function mergeCommitUrl()
+    {
+        if ($this->isMerged()) {
+            return sprintf(
+                '%s/commit/%s',
+                $this->event['base']['repo']['html_url'],
+                $this->event['pull_request']['merge_commit_sha']
+            );
+        }
+
+        return null;
+    }
+
+    public function mergedAt()
+    {
+        return $this->event['pull_request']['merged_at'];
+    }
+
+    public function mergedBy()
+    {
+        return $this->event['base']['merged_by'];
     }
 }

--- a/src/TicketBot/Synchronizer.php
+++ b/src/TicketBot/Synchronizer.php
@@ -26,6 +26,10 @@ class Synchronizer
         if ($pullRequestEvent->isOpened()) {
             $newIssue = $project->createTicket($pullRequestEvent);
             $jiraIssue = $this->jira->createIssue($project, $newIssue);
+            $pullRequestLink = $project->createPullRequestLink($pullRequestEvent);
+            $pullRequestLinkRelationship = $project->createPullRequestLinkRelationship($pullRequestEvent);
+
+            $this->jira->addRemoteLink($jiraIssue, $pullRequestLink, $pullRequestLinkRelationship);
 
             $this->github->addComment(
                 $pullRequestEvent->owner(),
@@ -61,7 +65,11 @@ class Synchronizer
 
             if ($issue->belongsTo($pullRequestEvent)) {
                 if ($pullRequestEvent->isClosed() && $pullRequestEvent->isMerged()) {
+                    $mergeCommitLink = $project->createMergeCommitLink($pullRequestEvent);
+                    $mergeCommitLinkRelationship = $project->createPullRequestLinkRelationship($pullRequestEvent);
+
                     $this->jira->resolveIssue($issue);
+                    $this->jira->addRemoteLink($issue, $mergeCommitLink, $mergeCommitLinkRelationship);
                 }
 
                 if ($pullRequestEvent->isClosed() && ! $pullRequestEvent->isMerged()) {

--- a/tests/TicketBot/JiraProjectTest.php
+++ b/tests/TicketBot/JiraProjectTest.php
@@ -51,4 +51,74 @@ ASSERT
 
         $this->assertEquals("A related Github Pull-Request [GH-127] was synchronize:\nhttps://github.com/doctrine/doctrine2/pulls/127", $comment);
     }
+
+    public function testCreatePullRequestLink()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'opened',
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+                'title' => 'Fix some issue',
+            )
+        ));
+
+        $project = new JiraProject();
+        $link = $project->createPullRequestLink($event);
+        $expected = new JiraRemoteLink(
+            'https://github.com/doctrine/doctrine2/pulls/127',
+            'Pull Request',
+            'Fix some issue'
+        );
+
+        $this->assertEquals($expected, $link);
+    }
+
+    public function testCreateMergeCommitLink()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'base' => array(
+                'merged_by' => 'deeky666',
+                'ref' => 'master',
+                'repo' => array(
+                    'html_url' => 'https://github.com/doctrine/doctrine2',
+                )
+            ),
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+                'merge_commit_sha' => '9049f1265b7d61be4a8904a9a27120d2064dab3b',
+                'merged' => true,
+                'merged_at' => '2015-05-05T23:40:27Z',
+            )
+        ));
+
+        $project = new JiraProject();
+        $link = $project->createMergeCommitLink($event);
+        $expected = new JiraRemoteLink(
+            'https://github.com/doctrine/doctrine2/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b',
+            'Merge Commit',
+            'deeky666 merged commit 9049f1265b7d61be4a8904a9a27120d2064dab3b into master at 2015-05-05T23:40:27Z'
+        );
+
+        $this->assertEquals($expected, $link);
+    }
+
+    public function testCreatePullRequestLinkRelationship()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'pull_request' => array(
+                'base' => array(
+                    'repo' => array(
+                        'name' => 'doctrine2',
+                    ),
+                ),
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+            )
+        ));
+
+        $project = new JiraProject();
+
+        $this->assertSame('relates to PR doctrine2#127', $project->createPullRequestLinkRelationship($event));
+    }
 }

--- a/tests/TicketBot/JiraXmlRpcTest.php
+++ b/tests/TicketBot/JiraXmlRpcTest.php
@@ -85,5 +85,13 @@ class JiraXmlRpcTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(count($issues) > 0);
         $this->assertContainsOnly('TicketBot\JiraIssue', $issues);
     }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testAddRemoteLinkThrowsException()
+    {
+        $this->jira->addRemoteLink(new JiraIssue(), new JiraRemoteLink('foo', 'bar'));
+    }
 }
 

--- a/tests/TicketBot/PullRequestEventTest.php
+++ b/tests/TicketBot/PullRequestEventTest.php
@@ -66,4 +66,97 @@ class PullRequestEventTest extends \PHPUnit_Framework_TestCase
             'DDC-4567',
         ), $terms);
     }
+
+    public function testRepositoryIssueId()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'synchronize',
+            'pull_request' => array(
+                'base' => array(
+                    'repo' => array(
+                        'name' => 'doctrine2',
+                    ),
+                ),
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+            )
+        ));
+
+        $this->assertSame('doctrine2#127', $event->repositoryIssueId());
+    }
+
+    public function testBaseBranch()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'synchronize',
+            'base' => array(
+                'ref' => 'master',
+            ),
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+            )
+        ));
+
+        $this->assertSame('master', $event->baseBranch());
+    }
+
+    public function testMergeCommitSha()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+                'merge_commit_sha' => '9049f1265b7d61be4a8904a9a27120d2064dab3b',
+            )
+        ));
+
+        $this->assertSame('9049f1265b7d61be4a8904a9a27120d2064dab3b', $event->mergeCommitSha());
+    }
+
+    public function testMergeCommitUrl()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'base' => array(
+                'repo' => array(
+                    'html_url' => 'https://github.com/doctrine/doctrine2',
+                ),
+            ),
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+                'merge_commit_sha' => '9049f1265b7d61be4a8904a9a27120d2064dab3b',
+                'merged' => true,
+            )
+        ));
+
+        $this->assertSame('9049f1265b7d61be4a8904a9a27120d2064dab3b', $event->mergeCommitSha());
+    }
+
+    public function testMergedAt()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+                'merged_at' => '2015-05-05T23:40:27Z',
+            )
+        ));
+
+        $this->assertSame('2015-05-05T23:40:27Z', $event->mergedAt());
+    }
+
+    public function testMergedBy()
+    {
+        $event = new PullRequestEvent(array(
+            'action' => 'closed',
+            'base' => array(
+                'merged_by' => 'deeky666',
+            ),
+            'pull_request' => array(
+                'html_url' => 'https://github.com/doctrine/doctrine2/pulls/127',
+            )
+        ));
+
+
+        $this->assertSame('deeky666', $event->mergedBy());
+    }
 }


### PR DESCRIPTION
This PR tries to automate the currently manual addition of PR & Merge Commit web links to the JIRA issue.
It will add a link to the PR on `open` event and add a Merge Commit link on `merge` event. Both links are grouped together via the same "relationship" like `relates to PR doctrine2#123`. This grouping is also a preparation for having other related PRs automatically being linked into the issue at a later time.

What is still unclear is how to implement `Jira::addRemoteLink()` in `JiraXmlRpc` API because it is nowhere documented that this action is supported. Also there comes the question whether it is time to switch to `JiraRest` API as XML-RPC API is deprecated and will be removed in JIRA 7.0.
